### PR TITLE
v0.3.0: Unify session ID to DEEP_SESSION_ID

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "deep-project",
       "description": "Split vague project requirements into well-scoped units for /deep-plan",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"
@@ -27,7 +27,7 @@
     {
       "name": "deep-plan",
       "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"
@@ -40,7 +40,7 @@
     {
       "name": "deep-implement",
       "description": "Implement code from /deep-plan sections with TDD, code review, and git workflow",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-plan",
   "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "piercelamb",
     "url": "https://github.com/piercelamb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-01-30
+
+### Changed
+- **Unified session ID** - Changed `DEEP_PLAN_SESSION_ID` to shared `DEEP_SESSION_ID`
+- **Normalized env var** - Changed `CLAUDE_SESSION_ID` to `DEEP_SESSION_ID` in env file writes and all scripts
+- SessionStart hook now checks if `DEEP_SESSION_ID` already matches before outputting
+- Prevents duplicate output when multiple deep-* plugins run together
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # /deep-plan, a Claude Code plugin
 
-![Version](https://img.shields.io/badge/version-0.2.0-blue)
+![Version](https://img.shields.io/badge/version-0.3.0-blue)
 ![Status](https://img.shields.io/badge/status-beta-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)
@@ -539,4 +539,4 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Version
 
-0.2.0
+0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deep-plan"
-version = "0.1.0"
+version = "0.3.0"
 description = "Claude Code deep planning plugin"
 requires-python = ">=3.11"
 dependencies = [

--- a/scripts/checks/generate-section-tasks.py
+++ b/scripts/checks/generate-section-tasks.py
@@ -111,7 +111,7 @@ def generate_section_tasks(
         return {
             **base_result,
             "success": False,
-            "error": "No CLAUDE_SESSION_ID available. Session hook may not have run.",
+            "error": "No DEEP_SESSION_ID available. Session hook may not have run.",
             "tasks_written": 0,
             "stats": {
                 "total": len(progress["defined_sections"]),

--- a/scripts/checks/setup-planning-session.py
+++ b/scripts/checks/setup-planning-session.py
@@ -553,7 +553,7 @@ def main():
             "plugin_root": str(plugin_root),
             "error": "No task list ID available. Cannot write tasks.",
             "error_details": {
-                "cause": "Neither CLAUDE_CODE_TASK_LIST_ID nor CLAUDE_SESSION_ID is set.",
+                "cause": "Neither CLAUDE_CODE_TASK_LIST_ID nor DEEP_SESSION_ID is set.",
                 "likely_reason": "The SessionStart hook did not run or failed to capture the session ID.",
                 "troubleshooting": [
                     "1. Verify the plugin is loaded: check that /deep-plan skill is available",

--- a/scripts/hooks/capture-session-id.py
+++ b/scripts/hooks/capture-session-id.py
@@ -57,15 +57,17 @@ def main() -> int:
     if not session_id:
         return 0
 
-    # PRIMARY: Output to Claude's context via additionalContext
-    # This works even when CLAUDE_ENV_FILE is unavailable or after /clear
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "SessionStart",
-            "additionalContext": f"DEEP_PLAN_SESSION_ID={session_id}",
+    # Check if DEEP_SESSION_ID is already set correctly
+    existing_session_id = os.environ.get("DEEP_SESSION_ID")
+    if existing_session_id != session_id:
+        # Not set or doesn't match - output to Claude's context via additionalContext
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": f"DEEP_SESSION_ID={session_id}",
+            }
         }
-    }
-    print(json.dumps(output))
+        print(json.dumps(output))
 
     # SECONDARY: Also try CLAUDE_ENV_FILE for bash commands (may not work)
     env_file = os.environ.get("CLAUDE_ENV_FILE")
@@ -81,8 +83,8 @@ def main() -> int:
 
             # Only write if not already present
             lines_to_write = []
-            if f"CLAUDE_SESSION_ID={session_id}" not in existing_content:
-                lines_to_write.append(f"export CLAUDE_SESSION_ID={session_id}\n")
+            if f"DEEP_SESSION_ID={session_id}" not in existing_content:
+                lines_to_write.append(f"export DEEP_SESSION_ID={session_id}\n")
             if (
                 transcript_path
                 and f"CLAUDE_TRANSCRIPT_PATH={transcript_path}" not in existing_content

--- a/scripts/lib/task_reconciliation.py
+++ b/scripts/lib/task_reconciliation.py
@@ -7,7 +7,7 @@ operations for Claude to execute.
 
 Key concepts:
 - CLAUDE_CODE_TASK_LIST_ID: User-specified task list for sharing across sessions
-- CLAUDE_SESSION_ID: Auto-captured session ID from SessionStart hook
+- DEEP_SESSION_ID: Auto-captured session ID from SessionStart hook
 - Conflict: Only when CLAUDE_CODE_TASK_LIST_ID is set AND has existing tasks
 - Position-based matching: Tasks are matched by numeric ID (position), NOT by subject
 
@@ -35,7 +35,7 @@ class TaskListSource(StrEnum):
 
     CONTEXT = "context"  # From --session-id arg (hook's additionalContext)
     USER_ENV = "user_env"  # From CLAUDE_CODE_TASK_LIST_ID
-    SESSION = "session"  # From CLAUDE_SESSION_ID env var
+    SESSION = "session"  # From DEEP_SESSION_ID env var
     NONE = "none"  # No task list ID available
 
 
@@ -55,7 +55,7 @@ class TaskListContext:
 
         DEPRECATED: Use from_args_and_env() instead for /clear support.
 
-        Priority: CLAUDE_CODE_TASK_LIST_ID > CLAUDE_SESSION_ID
+        Priority: CLAUDE_CODE_TASK_LIST_ID > DEEP_SESSION_ID
 
         Returns:
             TaskListContext with task_list_id, source, and is_user_specified
@@ -66,7 +66,7 @@ class TaskListContext:
     def from_args_and_env(cls, context_session_id: str | None = None) -> Self:
         """Get task list context from CLI args and environment.
 
-        Priority: --session-id (context) > CLAUDE_CODE_TASK_LIST_ID > CLAUDE_SESSION_ID
+        Priority: --session-id (context) > CLAUDE_CODE_TASK_LIST_ID > DEEP_SESSION_ID
 
         The context_session_id comes from the hook's additionalContext output,
         which Claude passes via --session-id argument. This is the most reliable
@@ -80,7 +80,7 @@ class TaskListContext:
             TaskListContext with task_list_id, source, is_user_specified, and
             session_id_matched diagnostic field
         """
-        env_session_id = os.environ.get("CLAUDE_SESSION_ID")
+        env_session_id = os.environ.get("DEEP_SESSION_ID")
         user_specified = os.environ.get("CLAUDE_CODE_TASK_LIST_ID")
 
         # Track if context and env matched (useful for debugging /clear issues)
@@ -196,7 +196,7 @@ def check_for_conflict(
     """Check if user-specified task list has existing tasks.
 
     IMPORTANT: Conflict detection ONLY applies when CLAUDE_CODE_TASK_LIST_ID
-    is set by the user. If we're using CLAUDE_SESSION_ID and find existing
+    is set by the user. If we're using DEEP_SESSION_ID and find existing
     tasks, that's just a normal resume scenario, not a conflict.
 
     Args:

--- a/scripts/lib/task_storage.py
+++ b/scripts/lib/task_storage.py
@@ -193,7 +193,7 @@ def check_for_conflict(
     """Check if user-specified task list has existing tasks.
 
     Only checks when CLAUDE_CODE_TASK_LIST_ID is explicitly set by user.
-    Session-based task lists (from CLAUDE_SESSION_ID) never conflict -
+    Session-based task lists (from DEEP_SESSION_ID) never conflict -
     existing tasks there are just a resume scenario.
 
     Args:

--- a/skills/deep-plan/SKILL.md
+++ b/skills/deep-plan/SKILL.md
@@ -120,7 +120,7 @@ Example: /deep-plan @planning/my-feature-spec.md
 
 ### 4. Setup Planning Session
 
-**First, check for session_id in your context.** Look for `DEEP_PLAN_SESSION_ID=xxx`
+**First, check for session_id in your context.** Look for `DEEP_SESSION_ID=xxx`
 which was set by the SessionStart hook. This appears in your context from when
 the session started.
 
@@ -130,10 +130,10 @@ uv run {plugin_root}/scripts/checks/setup-planning-session.py \
   --file "<file_path>" \
   --plugin-root "{plugin_root}" \
   --review-mode "{review_mode}" \
-  --session-id "{DEEP_PLAN_SESSION_ID}"
+  --session-id "{DEEP_SESSION_ID}"
 ```
 
-**IMPORTANT:** If `DEEP_PLAN_SESSION_ID` is in your context, you MUST pass it via
+**IMPORTANT:** If `DEEP_SESSION_ID` is in your context, you MUST pass it via
 `--session-id`. This ensures tasks work correctly after `/clear` commands.
 If it's not in your context, omit `--session-id` (fallback to env var).
 
@@ -377,10 +377,10 @@ Run generate-section-tasks.py to write section tasks directly to disk:
 ```bash
 uv run {plugin_root}/scripts/checks/generate-section-tasks.py \
   --planning-dir "<planning_dir>" \
-  --session-id "{DEEP_PLAN_SESSION_ID}"
+  --session-id "{DEEP_SESSION_ID}"
 ```
 
-**IMPORTANT:** If `DEEP_PLAN_SESSION_ID` is in your context, you MUST pass it via
+**IMPORTANT:** If `DEEP_SESSION_ID` is in your context, you MUST pass it via
 `--session-id`. This ensures tasks work correctly after `/clear` commands.
 If it's not in your context, omit `--session-id` (fallback to env var).
 
@@ -391,7 +391,7 @@ If it's not in your context, omit `--session-id` (fallback to env var).
 4. Updates all dependencies to reflect new positions
 
 **Handle based on result:**
-- If `success == false`: Read `error` and fix the issue (common: missing/invalid SECTION_MANIFEST in index.md, no CLAUDE_SESSION_ID). Re-run until successful.
+- If `success == false`: Read `error` and fix the issue (common: missing/invalid SECTION_MANIFEST in index.md, no DEEP_SESSION_ID). Re-run until successful.
 - If `state == "complete"`: All sections already written, skip to Final Verification.
 - Otherwise: Tasks were written successfully.
 

--- a/tests/test_generate_section_tasks.py
+++ b/tests/test_generate_section_tasks.py
@@ -129,7 +129,7 @@ END_MANIFEST -->
         assert output["tasks_written"] == 0
 
     def test_no_session_id_returns_error(self, run_script, tmp_path, sample_index_content):
-        """Should return error when no CLAUDE_SESSION_ID is available."""
+        """Should return error when no DEEP_SESSION_ID is available."""
         planning_dir = tmp_path / "planning"
         planning_dir.mkdir()
         sections_dir = planning_dir / "sections"
@@ -139,7 +139,7 @@ END_MANIFEST -->
 
         # Ensure no session ID env vars are set
         env_vars = {
-            "CLAUDE_SESSION_ID": "",
+            "DEEP_SESSION_ID": "",
             "CLAUDE_CODE_TASK_LIST_ID": "",
         }
         result = run_script(planning_dir, env_vars=env_vars)
@@ -147,12 +147,12 @@ END_MANIFEST -->
         assert result.returncode == 1
         output = json.loads(result.stdout)
         assert output["success"] is False
-        assert "CLAUDE_SESSION_ID" in output["error"]
+        assert "DEEP_SESSION_ID" in output["error"]
         assert output["tasks_written"] == 0
         assert output["task_list_source"] == "none"
 
     def test_writes_tasks_with_session_id(self, run_script, tmp_path, sample_index_content):
-        """Should write batch + section task files when CLAUDE_SESSION_ID is set."""
+        """Should write batch + section task files when DEEP_SESSION_ID is set."""
         planning_dir = tmp_path / "planning"
         planning_dir.mkdir()
         sections_dir = planning_dir / "sections"
@@ -170,7 +170,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -229,7 +229,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -269,7 +269,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -310,7 +310,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -371,7 +371,7 @@ END_MANIFEST -->
                 "blockedBy": [],
             }))
 
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -454,7 +454,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -511,7 +511,7 @@ END_MANIFEST -->
             shutil.rmtree(tasks_dir)
 
         try:
-            env_vars = {"CLAUDE_SESSION_ID": session_id}
+            env_vars = {"DEEP_SESSION_ID": session_id}
             result = run_script(planning_dir, env_vars=env_vars)
 
             assert result.returncode == 0
@@ -553,7 +553,7 @@ END_MANIFEST -->
                 shutil.rmtree(tasks_dir)
 
     def test_user_specified_task_list_id(self, run_script, tmp_path, sample_index_content):
-        """CLAUDE_CODE_TASK_LIST_ID should be preferred over CLAUDE_SESSION_ID."""
+        """CLAUDE_CODE_TASK_LIST_ID should be preferred over DEEP_SESSION_ID."""
         planning_dir = tmp_path / "planning"
         planning_dir.mkdir()
         sections_dir = planning_dir / "sections"
@@ -572,7 +572,7 @@ END_MANIFEST -->
         try:
             env_vars = {
                 "CLAUDE_CODE_TASK_LIST_ID": user_task_list_id,
-                "CLAUDE_SESSION_ID": session_id,
+                "DEEP_SESSION_ID": session_id,
             }
             result = run_script(planning_dir, env_vars=env_vars)
 

--- a/tests/test_setup_planning_session.py
+++ b/tests/test_setup_planning_session.py
@@ -28,7 +28,7 @@ class TestSetupPlanningSession:
             env = os.environ.copy()
             env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
             # Default session ID for tests (tasks written to tmp_path/.claude/tasks/)
-            env["CLAUDE_SESSION_ID"] = "test-session-default"
+            env["DEEP_SESSION_ID"] = "test-session-default"
             env["HOME"] = str(tmp_path)  # Isolate task writes to tmp_path
             if env_overrides:
                 env.update(env_overrides)
@@ -107,7 +107,7 @@ class TestSetupPlanningSession:
         assert output["initial_file"] == str(spec_file)
         # New sessions start at step 6 (codebase research decision)
         assert output["resume_from_step"] == 6
-        # Check for tasks_written (fixture provides CLAUDE_SESSION_ID)
+        # Check for tasks_written (fixture provides DEEP_SESSION_ID)
         assert "tasks_written" in output
         assert output["tasks_written"] > 0  # Should write 21 workflow tasks
 
@@ -289,7 +289,7 @@ END_MANIFEST -->
     # --- Task writing tests ---
 
     def test_writes_tasks_when_session_id_set(self, run_script, tmp_path, monkeypatch):
-        """Should write task files when CLAUDE_SESSION_ID is set."""
+        """Should write task files when DEEP_SESSION_ID is set."""
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Spec")
 
@@ -301,7 +301,7 @@ END_MANIFEST -->
         result = run_script(
             str(spec_file),
             env_overrides={
-                "CLAUDE_SESSION_ID": "test-session",
+                "DEEP_SESSION_ID": "test-session",
                 "HOME": str(tmp_path),
             }
         )
@@ -322,7 +322,7 @@ END_MANIFEST -->
 
         # Clear both session ID sources
         result = run_script(str(spec_file), env_overrides={
-            "CLAUDE_SESSION_ID": "",  # Empty to unset
+            "DEEP_SESSION_ID": "",  # Empty to unset
             "CLAUDE_CODE_TASK_LIST_ID": "",  # Empty to unset
         })
 
@@ -564,7 +564,7 @@ class TestSectionTasksIntegration:
             env = os.environ.copy()
             env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
             # Default session ID for tests (tasks written to tmp_path/.claude/tasks/)
-            env["CLAUDE_SESSION_ID"] = "test-session-default"
+            env["DEEP_SESSION_ID"] = "test-session-default"
             env["HOME"] = str(tmp_path)  # Isolate task writes to tmp_path
             if env_overrides:
                 env.update(env_overrides)
@@ -607,7 +607,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -653,7 +653,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -691,7 +691,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -733,7 +733,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -775,7 +775,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -843,7 +843,7 @@ END_MANIFEST -->
 
         result = run_script(
             str(spec_file),
-            env_overrides={"CLAUDE_SESSION_ID": "test-session", "HOME": str(tmp_path)}
+            env_overrides={"DEEP_SESSION_ID": "test-session", "HOME": str(tmp_path)}
         )
 
         assert result.returncode == 0
@@ -878,7 +878,7 @@ class TestConflictDetection:
             env = os.environ.copy()
             env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
             # Default session ID for tests (tasks written to tmp_path/.claude/tasks/)
-            env["CLAUDE_SESSION_ID"] = "test-session-default"
+            env["DEEP_SESSION_ID"] = "test-session-default"
             env["HOME"] = str(tmp_path)  # Isolate task writes to tmp_path
             if env_overrides:
                 env.update(env_overrides)
@@ -962,7 +962,7 @@ class TestConflictDetection:
         assert output["tasks_written"] == 21  # Workflow tasks written
 
     def test_no_conflict_with_session_id(self, run_script, tmp_path):
-        """Should NOT conflict when using CLAUDE_SESSION_ID (resume scenario)."""
+        """Should NOT conflict when using DEEP_SESSION_ID (resume scenario)."""
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Spec")
 
@@ -978,7 +978,7 @@ class TestConflictDetection:
         result = run_script(
             str(spec_file),
             env_overrides={
-                "CLAUDE_SESSION_ID": "sess-123",
+                "DEEP_SESSION_ID": "sess-123",
                 "HOME": str(tmp_path),
             }
         )


### PR DESCRIPTION
- Change DEEP_PLAN_SESSION_ID to shared DEEP_SESSION_ID
- Normalize CLAUDE_SESSION_ID to DEEP_SESSION_ID in env file writes and scripts
- Add conditional check: only output if DEEP_SESSION_ID not set or mismatches
- Prevents duplicate output when multiple deep-* plugins run together
- Update SKILL.md references
- Add tests for conditional behavior