### PR TITLE
fix: SubagentStop hook race condition — wait for transcript flush

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     {
       "name": "deep-plan",
       "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-plan",
   "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "piercelamb",
     "url": "https://github.com/piercelamb"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 .eggs/
 uv.lock
+.agents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-02-11
+
+### Fixed
+- **Section file race condition** — SubagentStop hook now waits for transcript JSONL to finish writing before reading it. Previously, 64% of section files contained garbage because Claude Code fires the hook before the final transcript entries are flushed to disk. The fix polls file size stability (200ms threshold) before reading, with a 5s timeout fallback.
+
 ## [0.3.0] - 2026-01-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # /deep-plan, a Claude Code plugin
 
-![Version](https://img.shields.io/badge/version-0.3.0-blue)
+![Version](https://img.shields.io/badge/version-0.3.1-blue)
 ![Status](https://img.shields.io/badge/status-beta-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)
@@ -547,4 +547,4 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Version
 
-0.3.0
+0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deep-plan"
-version = "0.3.0"
+version = "0.3.1"
 description = "Claude Code deep planning plugin"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- SubagentStop hook was reading transcript JSONL before Claude Code finished flushing final entries to disk, causing 64% of section files to contain garbage
- Added `wait_for_stable_file()` which polls file size until stable for 200ms before reading (4-13x safety margin over the 15-44ms race window)
- Bumped version to 0.3.1

## Test plan
- [x] 5 new tests covering: static file, growing file, timeout, nonexistent file, full race condition simulation
- [x] All 328 existing tests still pass (1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)