### PR TITLE
fix: inject DEEP_PLUGIN_ROOT for reliable script discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "deep-project",
       "description": "Split vague project requirements into well-scoped units for /deep-plan",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"
@@ -27,7 +27,7 @@
     {
       "name": "deep-plan",
       "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"
@@ -40,7 +40,7 @@
     {
       "name": "deep-implement",
       "description": "Implement code from /deep-plan sections with TDD, code review, and git workflow",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-plan",
   "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "piercelamb",
     "url": "https://github.com/piercelamb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-02-28
+
+### Fixed
+- **Plugin root discovery** — SessionStart hook now injects `DEEP_PLUGIN_ROOT` into Claude's context via `additionalContext`, eliminating slow `find` commands for script discovery. Falls back to filename-based search that works with both hyphen and underscore directory naming (fixes marketplace install path mismatch). ([piercelamb/deep-project#3](https://github.com/piercelamb/deep-project/issues/3))
+
 ## [0.3.1] - 2026-02-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # /deep-plan, a Claude Code plugin
 
-![Version](https://img.shields.io/badge/version-0.3.1-blue)
+![Version](https://img.shields.io/badge/version-0.3.2-blue)
 ![Status](https://img.shields.io/badge/status-beta-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)
@@ -549,4 +549,4 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Version
 
-0.3.1
+0.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deep-plan"
-version = "0.3.1"
+version = "0.3.2"
 description = "Claude Code deep planning plugin"
 requires-python = ">=3.11"
 dependencies = [

--- a/skills/deep-plan/SKILL.md
+++ b/skills/deep-plan/SKILL.md
@@ -35,14 +35,21 @@ SECURITY:
  Note: DEEP-PLAN will write many .md files to the planning directory you pass it
 ```
 
-**Find and run validate-env.sh:**
+**CRITICAL: Locate plugin root BEFORE running any scripts.**
+
+The SessionStart hook injects `DEEP_PLUGIN_ROOT=<path>` into your context. Look for it now — it appears alongside `DEEP_SESSION_ID` in your context from session startup. Use it as `plugin_root` for all script paths.
+
+**If `DEEP_PLUGIN_ROOT` is in your context**, run validate-env.sh directly:
 ```bash
-find "$(pwd)" -path "*/deep_plan/scripts/checks/validate-env.sh" -type f 2>/dev/null | head -1
+bash <DEEP_PLUGIN_ROOT value>/scripts/checks/validate-env.sh
 ```
 
+**Only if `DEEP_PLUGIN_ROOT` is NOT in your context** (hook didn't run), fall back to search:
 ```bash
-bash <script_path>
+find "$(pwd)" -name "validate-env.sh" -path "*/scripts/checks/*" -type f 2>/dev/null | head -1
 ```
+If not found: `find ~ -name "validate-env.sh" -path "*/scripts/checks/*" -path "*deep*plan*" -type f 2>/dev/null | head -1`
+Then run: `bash <found_path>`
 
 **Parse the JSON output:**
 ```json
@@ -56,7 +63,7 @@ bash <script_path>
 }
 ```
 
-**Store `plugin_root`** - it's used throughout the workflow.
+**Store `plugin_root`** from the JSON output - it's used throughout the workflow.
 
 ### 2. Handle Environment Errors
 


### PR DESCRIPTION
## Summary
- SessionStart hook now captures `CLAUDE_PLUGIN_ROOT` and emits it as `DEEP_PLUGIN_ROOT` in `additionalContext`, giving the SKILL.md instant access to the plugin root path
- SKILL.md updated to check context for `DEEP_PLUGIN_ROOT` first, with a filename-based `find` fallback that works for both hyphen (`deep-plan`) and underscore (`deep_plan`) directory naming
- Added 3 new tests for plugin root context injection

Fixes piercelamb/deep-project#3

## Test plan
- [x] All 319 tests pass
- [x] Verified via `--debug` that `DEEP_PLUGIN_ROOT` appears in SessionStart hook output
- [x] Confirmed Claude uses the injected path instead of running `find` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)