### PR TITLE
fix: Consolidate duplicate types, fix stale docs and confused comments

### DIFF
--- a/scripts/checks/generate-section-tasks.py
+++ b/scripts/checks/generate-section-tasks.py
@@ -148,17 +148,11 @@ def generate_section_tasks(
     # Build semantic_id -> position mapping for all tasks
     semantic_to_position: dict[str, int] = {}
 
-    # create-section-index is step 18, position = step - 1 = 17
-    # Actually step 18 maps to position 18 (see TASK_IDS: step 18 -> position 17... wait no)
-    # Let me check: TASK_IDS has step 18 -> "create-section-index"
-    # Position = step - 1 = 17? No wait, the mapping in setup-planning-session is:
-    # Context tasks: positions 1-4
-    # Workflow tasks: step 6 -> position 5, step 7 -> position 6, ..., step 22 -> position 21
-    # So step 18 -> position 17? No wait: step - 1 for steps 6+, but we have 4 context tasks
-    # Actually looking at build_semantic_to_position_map(): position = step_num - 1
-    # So step 18 -> position 17
-    # But generate-section-tasks is step 19 -> position 18
-    # And section tasks start at position 19 (SECTION_INSERT_POSITION)
+    # Position mapping: context tasks occupy positions 1-4, workflow steps
+    # start at position 5 (step 6 -> position 5). Formula: position = step_num - 1.
+    # create-section-index is step 18 -> position 17.
+    # generate-section-tasks is step 19 -> position 18.
+    # Section tasks start at position 19 (SECTION_INSERT_POSITION).
     semantic_to_position["create-section-index"] = 17
     semantic_to_position["generate-section-tasks"] = 18
     semantic_to_position["final-verification"] = final_ver_pos

--- a/scripts/lib/task_reconciliation.py
+++ b/scripts/lib/task_reconciliation.py
@@ -29,6 +29,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Self
 
+from lib.task_storage import ConflictInfo, CurrentTask
+
 
 class TaskListSource(StrEnum):
     """Source of the task list ID."""
@@ -120,17 +122,6 @@ class TaskListContext:
         )
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class CurrentTask:
-    """A task read from the task list directory."""
-
-    id: str
-    subject: str
-    status: str
-    description: str
-    active_form: str
-
-
 def read_current_tasks(task_list_id: str | None) -> dict[int, CurrentTask]:
     """Read current tasks from ~/.claude/tasks/<task_list_id>/
 
@@ -170,23 +161,6 @@ def read_current_tasks(task_list_id: str | None) -> dict[int, CurrentTask]:
             continue
 
     return tasks
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class ConflictInfo:
-    """Information about a task list conflict."""
-
-    task_list_id: str
-    existing_task_count: int
-    sample_subjects: list[str]
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary for JSON output."""
-        return {
-            "task_list_id": self.task_list_id,
-            "existing_task_count": self.existing_task_count,
-            "sample_subjects": self.sample_subjects,
-        }
 
 
 def check_for_conflict(

--- a/scripts/lib/task_storage.py
+++ b/scripts/lib/task_storage.py
@@ -35,12 +35,18 @@ def get_tasks_dir(task_list_id: str) -> Path:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class CurrentTask:
-    """A task read from disk."""
+    """A task read from disk or task list.
 
-    position: int
-    subject: str
-    status: str
+    Used by both task_storage (disk-based reads with position/blocks/blocked_by)
+    and task_reconciliation (reconciliation with id/active_form).
+    """
+
+    id: str = ""
+    position: int = 0
+    subject: str = ""
+    status: str = ""
     description: str = ""
+    active_form: str = ""
     blocks: tuple[str, ...] = ()
     blocked_by: tuple[str, ...] = ()
 

--- a/skills/deep-plan/references/section-index.md
+++ b/skills/deep-plan/references/section-index.md
@@ -25,7 +25,7 @@ index.md MUST contain two blocks at the top:
 
 ## PROJECT_CONFIG Block
 
-**index.md MUST start with a PROJECT_CONFIG block:**
+**index.md MUST contain a PROJECT_CONFIG block at the top:**
 
 ```markdown
 <!-- PROJECT_CONFIG
@@ -64,7 +64,7 @@ END_PROJECT_CONFIG -->
 
 ## SECTION_MANIFEST Block
 
-**index.md MUST start with a SECTION_MANIFEST block:**
+**After PROJECT_CONFIG, index.md MUST contain a SECTION_MANIFEST block:**
 
 ```markdown
 <!-- SECTION_MANIFEST
@@ -81,7 +81,7 @@ END_MANIFEST -->
 
 ### SECTION_MANIFEST Rules
 
-- Must be at the TOP of index.md (before any other content)
+- Must appear after PROJECT_CONFIG and before any other content
 - One section per line, format: `section-NN-name` (e.g., `section-01-foundation`)
 - Section numbers must be two digits with leading zero (01, 02, ... 12)
 - Section names use lowercase with hyphens (no spaces or underscores)

--- a/skills/deep-plan/references/section-splitting.md
+++ b/skills/deep-plan/references/section-splitting.md
@@ -63,9 +63,9 @@ Example: If the JSON output has 5 prompt files, send a single message with 5 Tas
 ### 4. Verify Files Were Written
 
 **The SubagentStop hook writes files automatically.** When each subagent completes, a hook:
-1. Parses the subagent's transcript for JSON output
-2. Extracts `sections_dir`, `filename`, and `content`
-3. Writes the file to `{sections_dir}/{filename}`
+1. Extracts the prompt file path from the first user message
+2. Derives the destination directory and filename from the prompt path structure
+3. Extracts the last assistant message as raw markdown content and writes it to the destination
 
 **You must verify the files exist** - hooks run in isolation and don't report back to Claude.
 

--- a/tests/test_dup_class_consolidation.py
+++ b/tests/test_dup_class_consolidation.py
@@ -1,0 +1,91 @@
+"""Tests for DUP fix: verify ConflictInfo and CurrentTask are not duplicated.
+
+These tests ensure that:
+- ConflictInfo is defined only in task_storage.py (canonical home)
+- CurrentTask is defined only in task_storage.py (canonical home)
+- task_reconciliation.py imports both from task_storage (no local definitions)
+- No circular imports exist between the two modules
+"""
+
+import inspect
+from pathlib import Path
+
+
+def test_task_storage_exports_conflict_info():
+    """from scripts.lib.task_storage import ConflictInfo should succeed."""
+    from scripts.lib.task_storage import ConflictInfo
+    assert ConflictInfo is not None
+
+
+def test_task_storage_exports_current_task():
+    """from scripts.lib.task_storage import CurrentTask should succeed."""
+    from scripts.lib.task_storage import CurrentTask
+    assert CurrentTask is not None
+
+
+def test_task_reconciliation_imports_conflict_info():
+    """from scripts.lib.task_reconciliation import ConflictInfo should succeed (via re-export)."""
+    from scripts.lib.task_reconciliation import ConflictInfo
+    assert ConflictInfo is not None
+
+
+def test_task_reconciliation_imports_current_task():
+    """from scripts.lib.task_reconciliation import CurrentTask should succeed (via re-export)."""
+    from scripts.lib.task_reconciliation import CurrentTask
+    assert CurrentTask is not None
+
+
+def test_task_reconciliation_no_local_conflict_info_class():
+    """task_reconciliation module should NOT define ConflictInfo class body (only imports it)."""
+    source_path = Path(__file__).parent.parent / "scripts" / "lib" / "task_reconciliation.py"
+    source = source_path.read_text()
+    # Should not have a class definition for ConflictInfo
+    assert "class ConflictInfo" not in source, (
+        "task_reconciliation.py still defines ConflictInfo locally — "
+        "it should import from task_storage instead"
+    )
+
+
+def test_task_reconciliation_no_local_current_task_class():
+    """task_reconciliation module should NOT define CurrentTask class body (only imports it)."""
+    source_path = Path(__file__).parent.parent / "scripts" / "lib" / "task_reconciliation.py"
+    source = source_path.read_text()
+    # Should not have a class definition for CurrentTask
+    assert "class CurrentTask" not in source, (
+        "task_reconciliation.py still defines CurrentTask locally — "
+        "it should import from task_storage instead"
+    )
+
+
+def test_no_circular_import():
+    """task_storage.py must NOT import from task_reconciliation (no circular dependency)."""
+    source_path = Path(__file__).parent.parent / "scripts" / "lib" / "task_storage.py"
+    source = source_path.read_text()
+    # Check for actual import statements, not mentions in comments/docstrings
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith('"""') or stripped.startswith("'"):
+            continue
+        assert "import" not in stripped or "task_reconciliation" not in stripped, (
+            f"task_storage.py imports from task_reconciliation — this creates a circular dependency: {stripped}"
+        )
+
+
+def test_classes_originate_from_task_storage():
+    """ConflictInfo and CurrentTask in task_reconciliation should originate from task_storage.
+
+    Note: Due to Python's import path mechanics (scripts.lib vs lib), the exact
+    class objects may differ, but both should be defined in task_storage.py.
+    """
+    from scripts.lib.task_reconciliation import ConflictInfo as ReconConflictInfo
+    from scripts.lib.task_reconciliation import CurrentTask as ReconCurrentTask
+
+    # Both classes should trace back to task_storage (regardless of import path prefix)
+    assert "task_storage" in ReconConflictInfo.__module__, (
+        f"ConflictInfo in task_reconciliation should originate from task_storage, "
+        f"but its module is {ReconConflictInfo.__module__}"
+    )
+    assert "task_storage" in ReconCurrentTask.__module__, (
+        f"CurrentTask in task_reconciliation should originate from task_storage, "
+        f"but its module is {ReconCurrentTask.__module__}"
+    )

--- a/tests/test_m3_comments.py
+++ b/tests/test_m3_comments.py
@@ -1,0 +1,52 @@
+"""Tests for M3 fix: verify confused comments are replaced with clear ones."""
+
+from pathlib import Path
+
+
+def test_no_confused_phrases_in_generate_section_tasks():
+    """Lines near the position mapping in generate-section-tasks.py should NOT contain
+    stream-of-consciousness phrases like 'Actually', 'No wait', or 'Let me check'."""
+    source_path = (
+        Path(__file__).parent.parent
+        / "scripts"
+        / "checks"
+        / "generate-section-tasks.py"
+    )
+    source = source_path.read_text()
+
+    confused_phrases = ["Actually", "No wait", "Let me check", "wait no"]
+    for phrase in confused_phrases:
+        assert phrase not in source, (
+            f"generate-section-tasks.py still contains confused phrase: '{phrase}'"
+        )
+
+
+def test_clear_position_documentation():
+    """Comments near semantic_to_position assignments should explain the mapping formula."""
+    source_path = (
+        Path(__file__).parent.parent
+        / "scripts"
+        / "checks"
+        / "generate-section-tasks.py"
+    )
+    source = source_path.read_text()
+
+    # Find the block around the semantic_to_position assignments
+    lines = source.splitlines()
+    mapping_lines = []
+    for i, line in enumerate(lines):
+        if 'semantic_to_position["create-section-index"]' in line:
+            # Grab a window of comment lines above this assignment
+            start = max(0, i - 10)
+            mapping_lines = lines[start : i + 1]
+            break
+
+    mapping_block = "\n".join(mapping_lines)
+    # Should contain the position formula explanation
+    assert "step" in mapping_block.lower() and "position" in mapping_block.lower(), (
+        "Position mapping comments should explain the step-to-position formula"
+    )
+    # Should reference SECTION_INSERT_POSITION
+    assert "SECTION_INSERT_POSITION" in mapping_block, (
+        "Position mapping comments should reference SECTION_INSERT_POSITION"
+    )


### PR DESCRIPTION
- CurrentTask and ConflictInfo are defined in both task_storage.py and task_reconciliation.py with different fields. Consolidated both into task_storage.py so there's a single definition to maintain.
- generate-section-tasks.py has a comment block that reads like stream-of-consciousness notes ("Actually", "No wait", "Let me check"). Replaced with a clean summary of the position mapping formula.
- section-index.md says both PROJECT_CONFIG and SECTION_MANIFEST blocks "MUST start" the file, which is contradictory. Clarified ordering.
- section-splitting.md describes the SubagentStop hook as parsing JSON with sections_dir/filename/content fields, but the actual hook extracts the prompt path and writes the last assistant message as raw markdown. Updated to match what the hook actually does.

All 341 existing tests pass.