### PR TITLE
fix: regex null safety, elapsed time unit, and remove dead code

### DIFF
--- a/scripts/hooks/write-section-on-stop.py
+++ b/scripts/hooks/write-section-on-stop.py
@@ -87,7 +87,7 @@ def wait_for_stable_file(path: str, stability_ms: int = 200, timeout_s: float = 
             last_size = size
             stable_since = time.time()
         elif (time.time() - stable_since) >= stability_ms / 1000:
-            debug_log(f"File stable at {size} bytes after {(time.time() - (stable_since - stability_ms / 1000)):.0f}ms")
+            debug_log(f"File stable at {size} bytes after {(time.time() - (stable_since - stability_ms / 1000)) * 1000:.0f}ms")
             return
 
         time.sleep(poll_ms / 1000)

--- a/scripts/lib/sections.py
+++ b/scripts/lib/sections.py
@@ -15,6 +15,12 @@ MANIFEST_START = '<!-- SECTION_MANIFEST'
 MANIFEST_END = 'END_MANIFEST -->'
 
 
+def _section_num(name: str) -> int:
+    """Extract section number for sorting. Returns 0 if pattern doesn't match."""
+    m = re.search(r'section-(\d+)', name)
+    return int(m.group(1)) if m else 0
+
+
 def parse_manifest_block(content: str) -> dict:
     """Parse the SECTION_MANIFEST block from index.md content.
 
@@ -113,12 +119,15 @@ def parse_manifest_block(content: str) -> dict:
         }
 
     # Sort by section number
-    sections.sort(key=lambda x: int(SECTION_NAME_PATTERN.match(x).group(1)))
+    sections.sort(key=_section_num)
 
     # Validate sequential numbering (warn if gaps)
     expected_num = 1
     for section in sections:
-        actual_num = int(SECTION_NAME_PATTERN.match(section).group(1))
+        match = SECTION_NAME_PATTERN.match(section)
+        if not match:
+            continue
+        actual_num = int(match.group(1))
         if actual_num != expected_num:
             warnings.append(
                 f"Section numbering gap: expected section-{expected_num:02d}, "
@@ -235,7 +244,7 @@ def get_completed_sections(sections_dir: Path) -> list[str]:
         completed.append(f.stem)
 
     # Sort by section number
-    completed.sort(key=lambda x: int(re.search(r'section-(\d+)', x).group(1)))
+    completed.sort(key=_section_num)
 
     return completed
 

--- a/scripts/lib/task_storage.py
+++ b/scripts/lib/task_storage.py
@@ -82,39 +82,6 @@ def read_current_tasks(task_list_id: str) -> dict[int, CurrentTask]:
     return result
 
 
-def needs_migration(current_tasks: dict[int, CurrentTask]) -> bool:
-    """Check if tasks have old structure that needs migration.
-
-    Old structure (broken):
-    - Position 19: "Write Section Files"
-    - Position 20: "Final Verification"
-    - Position 21: "Output Summary"
-    - Positions 22+: Section tasks (batch and section tasks)
-    - Final Verification blockedBy 19 (write-sections), NOT the last batch
-
-    New structure (correct):
-    - Positions 19+: Section tasks (batch and section tasks)
-    - Final Verification at position 19 + section_count
-    - Output Summary at position 19 + section_count + 1
-    - Final Verification blockedBy last batch
-
-    Returns:
-        True if old structure detected (has section at 22+ AND Final Verification at 20)
-    """
-    # Check for section task at position 22
-    has_section_at_22 = False
-    if 22 in current_tasks:
-        subject_lower = current_tasks[22].subject.lower()
-        has_section_at_22 = "batch" in subject_lower or "section" in subject_lower
-
-    # Check for Final Verification at position 20
-    has_final_at_20 = False
-    if 20 in current_tasks:
-        has_final_at_20 = "Final Verification" in current_tasks[20].subject
-
-    return has_section_at_22 and has_final_at_20
-
-
 @dataclass(frozen=True, slots=True, kw_only=True)
 class TaskToWrite:
     """A task to write to disk."""

--- a/tests/test_section_num_helper.py
+++ b/tests/test_section_num_helper.py
@@ -1,0 +1,35 @@
+"""Test the _section_num helper function for null-safe regex extraction."""
+
+from scripts.lib.sections import _section_num
+
+
+class TestSectionNumHelper:
+    """Tests for the _section_num helper that safely extracts section numbers."""
+
+    def test_valid_section_name(self):
+        assert _section_num("section-05-foo") == 5
+
+    def test_valid_section_double_digit(self):
+        assert _section_num("section-12-bar-baz") == 12
+
+    def test_non_matching_name_returns_zero(self):
+        assert _section_num("not-a-section-file") == 0
+
+    def test_empty_string_returns_zero(self):
+        assert _section_num("") == 0
+
+    def test_sort_with_non_matching_names(self):
+        """Sorting a list containing non-matching names doesn't crash."""
+        names = ["section-03-c", "bad-name", "section-01-a", "section-02-b"]
+        sorted_names = sorted(names, key=_section_num)
+        # bad-name gets 0, so it sorts first
+        assert sorted_names[0] == "bad-name"
+        assert sorted_names[1] == "section-01-a"
+
+    def test_section_prefix_only(self):
+        """Just 'section-01' without a name part still extracts number."""
+        assert _section_num("section-01") == 1
+
+    def test_single_digit(self):
+        """Single digit section number works."""
+        assert _section_num("section-3-name") == 3

--- a/tests/test_write_section_on_stop.py
+++ b/tests/test_write_section_on_stop.py
@@ -505,6 +505,31 @@ class TestWaitForStableFile:
         assert elapsed >= 0.25
         assert elapsed < 0.6
 
+    def test_elapsed_time_logged_in_milliseconds(self, tmp_path, monkeypatch):
+        """Debug log should report elapsed time in milliseconds, not seconds."""
+        f = tmp_path / "stable.jsonl"
+        f.write_text("content\n")
+
+        logged_messages = []
+        monkeypatch.setattr(_mod, "debug_log", lambda msg: logged_messages.append(msg))
+
+        wait_for_stable_file(str(f), stability_ms=100, poll_ms=25)
+
+        # Find the "File stable" log message
+        stable_msgs = [m for m in logged_messages if "File stable" in m]
+        assert len(stable_msgs) == 1, f"Expected 1 stable message, got {logged_messages}"
+
+        # Extract the reported ms value
+        import re
+        match = re.search(r'after (\d+)ms', stable_msgs[0])
+        assert match, f"No 'after Nms' found in: {stable_msgs[0]}"
+        reported_ms = int(match.group(1))
+
+        # The elapsed time should be in a reasonable millisecond range (50-500ms),
+        # not in the 0-1 range you'd get if reporting seconds
+        assert reported_ms >= 50, f"Elapsed {reported_ms}ms is too low — likely seconds not ms"
+        assert reported_ms < 2000, f"Elapsed {reported_ms}ms is unexpectedly high"
+
     def test_race_condition_simulation(self, hook_script, tmp_path):
         """Simulate the actual race: transcript incomplete when hook starts, completed during wait.
 


### PR DESCRIPTION
- The section sorting in sections.py assumes every filename matches the expected pattern, but if one doesn't, it blows up with an AttributeError on None. Added a small helper that safely returns 0 for anything that doesn't match.

- The stability wait log in write-section-on-stop.py says "ms" but the actual value is in seconds, so it always shows something like "0ms" even when it waited a full second. Multiplied by 1000 so the log is accurate.

- needs_migration() in task_storage.py isn't called from anywhere. Removed it to keep things clean. Maybe left over from early days?

All 339 existing tests pass.