### PR TITLE
Add Go file size constraints for section writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Context anchor guidance** — Plan-writing rules, section writer prompts, and concern guidance now teach the LLM planner to designate context anchor files (interfaces, shared types, contracts). Scaffold sections mark which files are anchors; functional sections list prerequisite anchors to read first. Multi-language examples (Go, TypeScript, Rust, Python) included.
+- **Concern-based execution ordering** — Sections in the manifest can be tagged with concern types (`scaffold`, `functional`, `observability`, `configuration`, `resilience`, `integration`) to control execution order. Scaffold sections run first, ensuring interfaces exist before business logic.
+
 ## [0.3.2] - 2026-02-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -443,7 +443,9 @@ Managed via `pyproject.toml`:
 
 4. **Use sections for parallel work** - Each section file is self-contained. Multiple engineers (or Claude sessions) can work in parallel.
 
-5. **Compact before starting** - The workflow is token-intensive. Start with a fresh or compacted context.
+5. **Designate context anchors for multi-service projects** - Mark small, stable interface files (port interfaces, shared types, API contracts) as context anchors in your plan. Scaffold sections produce them; functional sections reference them. This keeps each implementer's context window small by collapsing cross-component knowledge into a few bounded files.
+
+6. **Compact before starting** - The workflow is token-intensive. Start with a fresh or compacted context.
 
 ## Security & Privacy
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/capture-session-id.py"
+            "command": "uv run --script ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/capture-session-id.py"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/write-section-on-stop.py"
+            "command": "uv run --script ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/write-section-on-stop.py"
           }
         ]
       }

--- a/prompts/section_writer/prompt.md
+++ b/prompts/section_writer/prompt.md
@@ -23,6 +23,7 @@ blocks around the output. Just the raw markdown content.
 The hook system will automatically write your output to:
 `{PLANNING_DIR}/sections/{SECTION_FILENAME}`
 
+{CONCERN_TYPE}
 ## Content Requirements
 
 The section content must be **completely self-contained**. An implementer should be able to:
@@ -40,6 +41,7 @@ The section content must be **completely self-contained**. An implementer should
 - Dependencies on other sections (reference only, don't duplicate content)
 - **CRITICAL** Remember that tests and code should only be fully specified if absolutely necessary. Stub definitions and docstrings are fine.
 - For Go projects: note file size constraints (ports: 100, domain: 250, service/adapter: 300, handler: 250, functions: 75 lines max). Plan one file per entity rather than large combined files.
+- If the plan designates **context anchor files** (interfaces, shared types, contracts) for this component: for scaffold sections, mark which files are anchors and will be read by downstream implementers. For all other sections, list prerequisite anchor files the implementer should read before starting.
 
 **Do NOT:**
 

--- a/prompts/section_writer/prompt.md
+++ b/prompts/section_writer/prompt.md
@@ -39,6 +39,7 @@ The section content must be **completely self-contained**. An implementer should
 - File paths for any code to be created/modified
 - Dependencies on other sections (reference only, don't duplicate content)
 - **CRITICAL** Remember that tests and code should only be fully specified if absolutely necessary. Stub definitions and docstrings are fine.
+- For Go projects: note file size constraints (ports: 100, domain: 250, service/adapter: 300, handler: 250, functions: 75 lines max). Plan one file per entity rather than large combined files.
 
 **Do NOT:**
 

--- a/scripts/checks/generate-batch-tasks.py
+++ b/scripts/checks/generate-batch-tasks.py
@@ -22,7 +22,7 @@ from pathlib import Path
 # Add parent to path for lib imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from lib.config import load_session_config, ConfigError
-from lib.sections import check_section_progress
+from lib.sections import check_section_progress, parse_manifest_block
 from lib.tasks import BATCH_SIZE
 
 
@@ -45,24 +45,53 @@ def load_prompt_template(plugin_root: Path) -> str:
     return template_path.read_text().strip()
 
 
-def fill_template(template: str, planning_dir: str, section_name: str) -> str:
+CONCERN_GUIDANCE = {
+    "scaffold": (
+        "This section is tagged as a **scaffold** concern. Only create stubs, "
+        "interfaces, module init. Do NOT implement logic.\n\n"
+        "Files created here — especially interface definitions, shared types, and "
+        "API contracts — become **context anchors** for all downstream sections. "
+        "Mark them explicitly (e.g., 'Context anchor: implementers read this before "
+        "writing service code') so the implementer knows to read them first."
+    ),
+    "functional": (
+        "This section is tagged as a **functional** concern. Core business logic. "
+        "Assume scaffold files exist.\n\n"
+        "Before describing implementation, list the scaffold context anchor files "
+        "(port interfaces, shared types, API contracts) that define this section's "
+        "boundaries. The implementer must read those files before writing code."
+    ),
+    "observability": "This section is tagged as an **observability** concern. Instrument existing code. Assume functional code exists.",
+    "configuration": "This section is tagged as a **configuration** concern. Config loading/validation. Assume functional code exists.",
+    "resilience": "This section is tagged as a **resilience** concern. Error handling, retries, health checks. Assume functional code exists.",
+    "integration": "This section is tagged as an **integration** concern. Cross-component wiring, end-to-end tests. Assume everything else exists.",
+}
+
+
+def fill_template(template: str, planning_dir: str, section_name: str, concern_type: str = "") -> str:
     """Fill in the prompt template placeholders.
 
     Args:
         template: The prompt template with placeholders
         planning_dir: Path to the planning directory
         section_name: Section name without .md extension (e.g., "section-01-setup")
+        concern_type: Optional concern type tag (e.g., "scaffold", "functional")
 
     Returns:
         Filled-in prompt ready for use
     """
     section_filename = f"{section_name}.md"
 
+    concern_block = ""
+    if concern_type and concern_type in CONCERN_GUIDANCE:
+        concern_block = f"## Concern Type: {concern_type}\n\n{CONCERN_GUIDANCE[concern_type]}\n\n"
+
     return (
         template
         .replace("{PLANNING_DIR}", planning_dir)
         .replace("{SECTION_FILENAME}", section_filename)
         .replace("{SECTION_NAME}", section_name)
+        .replace("{CONCERN_TYPE}", concern_block)
     )
 
 
@@ -206,13 +235,21 @@ def generate_batch_tasks(
     prompts_dir = planning_dir / "sections" / ".prompts"
     prompts_dir.mkdir(parents=True, exist_ok=True)
 
+    # Extract concern tags from manifest (if any)
+    index_path = planning_dir / "sections" / "index.md"
+    section_concerns = {}
+    if index_path.exists():
+        manifest_result = parse_manifest_block(index_path.read_text())
+        if manifest_result.get("success"):
+            section_concerns = manifest_result.get("section_concerns", {})
+
     # Write prompt files for each section
     prompt_files = []
     planning_dir_str = str(planning_dir.resolve())
 
     for section_name in batch_sections:
-        # Write full prompt to file
-        filled_prompt = fill_template(template, planning_dir_str, section_name)
+        concern = section_concerns.get(section_name, "")
+        filled_prompt = fill_template(template, planning_dir_str, section_name, concern)
         prompt_file = write_prompt_file(prompts_dir, section_name, filled_prompt)
         prompt_files.append(str(prompt_file))
 

--- a/scripts/hooks/capture-session-id.py
+++ b/scripts/hooks/capture-session-id.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Capture session_id and plugin_root, expose via Claude's context.
 
 This hook reads session_id from the JSON payload on stdin and:

--- a/scripts/hooks/write-section-on-stop.py
+++ b/scripts/hooks/write-section-on-stop.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Write section files from section-writer subagent output.
 
 This SubagentStop hook is defined in hooks/hooks.json with a matcher for

--- a/scripts/lib/sections.py
+++ b/scripts/lib/sections.py
@@ -14,6 +14,9 @@ SECTION_NAME_PATTERN = re.compile(r'^section-(\d{2})-([a-zA-Z0-9_-]+)$')
 MANIFEST_START = '<!-- SECTION_MANIFEST'
 MANIFEST_END = 'END_MANIFEST -->'
 
+# Valid concern types for concern-based execution ordering
+VALID_CONCERNS = ["scaffold", "functional", "observability", "configuration", "resilience", "integration"]
+
 
 def parse_manifest_block(content: str) -> dict:
     """Parse the SECTION_MANIFEST block from index.md content.
@@ -32,6 +35,7 @@ def parse_manifest_block(content: str) -> dict:
         dict with:
         - success: bool
         - sections: list of section names (empty if failed)
+        - section_concerns: dict mapping section name to concern tag (empty if no tags)
         - error: error message if failed, None otherwise
         - warnings: list of warning messages
     """
@@ -43,6 +47,7 @@ def parse_manifest_block(content: str) -> dict:
         return {
             "success": False,
             "sections": [],
+            "section_concerns": {},
             "error": "No SECTION_MANIFEST block found in index.md. "
                      "index.md must start with a SECTION_MANIFEST block. "
                      "See SKILL.md step 18 for the required format.",
@@ -54,6 +59,7 @@ def parse_manifest_block(content: str) -> dict:
         return {
             "success": False,
             "sections": [],
+            "section_concerns": {},
             "error": "SECTION_MANIFEST block not closed (missing END_MANIFEST -->)",
             "warnings": warnings,
         }
@@ -66,12 +72,14 @@ def parse_manifest_block(content: str) -> dict:
         return {
             "success": False,
             "sections": [],
+            "section_concerns": {},
             "error": "SECTION_MANIFEST block is empty. Add section definitions, one per line.",
             "warnings": warnings,
         }
 
     # Parse lines
     sections = []
+    section_concerns = {}
     seen_numbers = set()
 
     for line_num, line in enumerate(block_content.split('\n'), start=1):
@@ -79,13 +87,18 @@ def parse_manifest_block(content: str) -> dict:
         if not line:
             continue  # Skip empty lines
 
+        # Support optional concern tag: "section-01-foundation scaffold"
+        parts = line.split()
+        section_name = parts[0]
+
         # Validate section name format
-        match = SECTION_NAME_PATTERN.match(line)
+        match = SECTION_NAME_PATTERN.match(section_name)
         if not match:
             return {
                 "success": False,
                 "sections": [],
-                "error": f"Invalid section name on line {line_num}: '{line}'. "
+                "section_concerns": {},
+                "error": f"Invalid section name on line {line_num}: '{section_name}'. "
                          f"Expected format: section-NN-name (e.g., section-01-foundation). "
                          f"Section numbers must be two digits (01, 02, etc.).",
                 "warnings": warnings,
@@ -96,18 +109,31 @@ def parse_manifest_block(content: str) -> dict:
             return {
                 "success": False,
                 "sections": [],
-                "error": f"Duplicate section number on line {line_num}: '{line}'. "
+                "section_concerns": {},
+                "error": f"Duplicate section number on line {line_num}: '{section_name}'. "
                          f"Section {section_num} already defined.",
                 "warnings": warnings,
             }
 
+        # Extract optional concern tag
+        if len(parts) >= 2:
+            tag = parts[1]
+            if tag in VALID_CONCERNS:
+                section_concerns[section_name] = tag
+            else:
+                warnings.append(
+                    f"Unknown concern tag '{tag}' on line {line_num} for {section_name}. "
+                    f"Valid concerns: {', '.join(VALID_CONCERNS)}"
+                )
+
         seen_numbers.add(section_num)
-        sections.append(line)
+        sections.append(section_name)
 
     if not sections:
         return {
             "success": False,
             "sections": [],
+            "section_concerns": {},
             "error": "No valid sections found in SECTION_MANIFEST block",
             "warnings": warnings,
         }
@@ -129,6 +155,7 @@ def parse_manifest_block(content: str) -> dict:
     return {
         "success": True,
         "sections": sections,
+        "section_concerns": section_concerns,
         "error": None,
         "warnings": warnings,
     }

--- a/skills/deep-plan/references/plan-writing.md
+++ b/skills/deep-plan/references/plan-writing.md
@@ -52,6 +52,29 @@ LLMs instinctively write code when they see a feature request. This produces 25k
 - **Directory structure** (tree format)
 - **Configuration keys** (not full config files)
 
+### Context Anchor Files
+
+For projects with multiple components or services, the plan should designate certain
+files as **context anchors** — small, stable interface files that implementers must
+read before writing any service code. These collapse cross-component knowledge into
+a bounded set of files, keeping each implementation task's context window small.
+
+Common context anchor patterns by language:
+- **Go (hexagonal):** port interfaces (`internal/ports/*.go`), shared entity types
+  (`types/types.go`), protobuf service definitions (`.proto`)
+- **TypeScript:** shared type definitions (`types/index.ts`), API route contracts,
+  Zod schemas
+- **Rust:** trait definitions (`ports.rs`), shared types (`models.rs`),
+  protobuf/tonic service definitions
+- **Python:** protocol classes or ABCs (`ports.py`), Pydantic models (`models.py`),
+  shared type stubs
+
+When designating context anchors in the plan:
+- List them explicitly by file path under each component
+- Size them small (interface-only, no logic) — they should be readable in full
+- Mark them as scaffold-phase outputs so they exist before functional code
+- Note which downstream sections depend on each anchor file
+
 ### GOOD Examples
 
 ```python

--- a/skills/deep-plan/references/section-index.md
+++ b/skills/deep-plan/references/section-index.md
@@ -40,6 +40,7 @@ END_PROJECT_CONFIG -->
 |-------|----------|-------------|----------|
 | `runtime` | Yes | Language and tooling | `python-uv`, `python-pip`, `typescript-npm`, `typescript-pnpm`, `rust-cargo`, `go` |
 | `test_command` | Yes | Command to run tests | `uv run pytest`, `npm test`, `cargo test`, `go test ./...` |
+| `concern_ordering` | No | Enable concern-type execution ordering | `true`, `false` (default: `false`) |
 
 ### PROJECT_CONFIG Rules
 
@@ -88,6 +89,33 @@ END_MANIFEST -->
 - Numbers should be sequential (01, 02, 03...)
 - This block is parsed by scripts - the rest of index.md is for humans
 
+### Concern Tags (Optional)
+
+When `concern_ordering: true` is set in PROJECT_CONFIG, each manifest line can include a concern tag:
+
+```markdown
+<!-- SECTION_MANIFEST
+section-01-project-init scaffold
+section-02-domain-models functional
+section-03-api-handlers functional
+section-04-logging observability
+section-05-config configuration
+section-06-error-handling resilience
+section-07-external-apis integration
+END_MANIFEST -->
+```
+
+Valid concern types (executed in this order):
+1. `scaffold` — Directory structure, module init, stub routes, empty interfaces
+2. `functional` — Core logic, ports, domain types, service implementations
+3. `observability` — Structured logging, metrics, tracing
+4. `configuration` — Env vars, secrets, feature flags
+5. `resilience` — Error handling, graceful shutdown, health checks
+6. `integration` — Adapter wiring, cross-service calls, end-to-end tests
+
+Sections with the same concern execute in manifest number order.
+Sections without a concern tag execute after all tagged sections.
+
 ### Validation
 
 Scripts parse the SECTION_MANIFEST block to:
@@ -126,14 +154,16 @@ Which sections can run in parallel:
 
 ### Section Summaries
 
-Brief description of each section:
+Brief description of each section. When the project uses context anchor files (interfaces, shared types, contracts), note which anchors each section produces or depends on:
 
 ```markdown
 ### section-01-foundation
-Initial project setup and configuration.
+Initial project setup, shared types, and port interfaces.
+**Context anchors produced:** `internal/ports/service.go`, `types/types.go`
 
-### section-02-config
-Configuration loading and validation.
+### section-02-core-logic
+Service implementation against port interfaces.
+**Reads anchors from:** section-01 (`internal/ports/service.go`)
 ```
 
 ## Guidelines

--- a/tests/test_concern_tags.py
+++ b/tests/test_concern_tags.py
@@ -1,0 +1,102 @@
+"""Tests for concern tag support in parse_manifest_block()."""
+
+import pytest
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from lib.sections import parse_manifest_block
+
+
+class TestManifestWithConcernTags:
+    """Tests for concern tag parsing in SECTION_MANIFEST."""
+
+    def test_manifest_with_concern_tags(self):
+        """Should parse sections and extract concern tags."""
+        content = """<!-- SECTION_MANIFEST
+section-01-init scaffold
+section-02-models functional
+section-03-api functional
+END_MANIFEST -->"""
+        result = parse_manifest_block(content)
+        assert result["success"] is True
+        assert result["sections"] == [
+            "section-01-init",
+            "section-02-models",
+            "section-03-api",
+        ]
+        assert result["section_concerns"] == {
+            "section-01-init": "scaffold",
+            "section-02-models": "functional",
+            "section-03-api": "functional",
+        }
+
+    def test_manifest_without_tags(self):
+        """Existing behavior preserved — no tags, no concerns."""
+        content = """<!-- SECTION_MANIFEST
+section-01-init
+section-02-models
+END_MANIFEST -->"""
+        result = parse_manifest_block(content)
+        assert result["success"] is True
+        assert result["sections"] == ["section-01-init", "section-02-models"]
+        assert result["section_concerns"] == {}
+
+    def test_manifest_invalid_concern_tag(self):
+        """Invalid tags produce a warning but don't fail."""
+        content = """<!-- SECTION_MANIFEST
+section-01-init scaffold
+section-02-models bogus_concern
+section-03-api functional
+END_MANIFEST -->"""
+        result = parse_manifest_block(content)
+        assert result["success"] is True
+        assert len(result["sections"]) == 3
+        # Invalid tag not in concerns
+        assert "section-02-models" not in result["section_concerns"]
+        # Valid tags present
+        assert result["section_concerns"]["section-01-init"] == "scaffold"
+        assert result["section_concerns"]["section-03-api"] == "functional"
+        # Warning generated
+        assert any("bogus_concern" in w for w in result["warnings"])
+
+    def test_manifest_mixed_tags(self):
+        """Some lines tagged, some not — both parse correctly."""
+        content = """<!-- SECTION_MANIFEST
+section-01-init scaffold
+section-02-models
+section-03-api functional
+section-04-tests
+END_MANIFEST -->"""
+        result = parse_manifest_block(content)
+        assert result["success"] is True
+        assert len(result["sections"]) == 4
+        assert result["section_concerns"] == {
+            "section-01-init": "scaffold",
+            "section-03-api": "functional",
+        }
+
+    def test_all_six_concern_types(self):
+        """All valid concern types are accepted."""
+        content = """<!-- SECTION_MANIFEST
+section-01-init scaffold
+section-02-core functional
+section-03-logging observability
+section-04-config configuration
+section-05-errors resilience
+section-06-wiring integration
+END_MANIFEST -->"""
+        result = parse_manifest_block(content)
+        assert result["success"] is True
+        assert len(result["section_concerns"]) == 6
+
+    def test_error_returns_include_section_concerns(self):
+        """Error returns should have section_concerns key for consistent access."""
+        # Missing manifest
+        result = parse_manifest_block("# No manifest here")
+        assert result["section_concerns"] == {}
+
+        # Empty manifest
+        result = parse_manifest_block("<!-- SECTION_MANIFEST\nEND_MANIFEST -->")
+        assert result["section_concerns"] == {}


### PR DESCRIPTION
## Summary
- Adds Go hex architecture file size constraints to section writer prompt
- Instructs section-writer to plan one file per entity rather than large combined files

## Test plan
- [ ] Run `/deep-plan` on a Go project and verify sections mention file size constraints