### PR TITLE
marketplace: bump lodestone to 0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "piercelamb-plugins",
   "description": "Claude Code plugins by Pierce Lamb",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "owner": {
     "name": "Pierce Lamb",
     "url": "https://github.com/piercelamb"
@@ -72,7 +72,7 @@
     {
       "name": "lodestone",
       "description": "Local research corpus over arXiv papers, blog posts, and code repos with paper-grounded MCP search/read tools",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"


### PR DESCRIPTION
## Summary

- Sync the lodestone entry in this repo's copy of the `piercelamb-plugins` marketplace catalog: version `0.1.0` → `0.1.1`.
- Bump the top-level catalog version `1.1.0` → `1.1.1`.

No code changes to deep-plan. Its plugin version stays at 0.3.2.

Tracks piercelamb/lodestone#73, which adds a 7-day PyPI supply-chain quarantine and cuts lodestone 0.1.1.

## Test plan

- [x] Single-file, two-line diff in `.claude-plugin/marketplace.json`.
- [x] Top-level marketplace version matches the lodestone-repo source of truth (1.1.1).
- [x] Lodestone entry version matches `lodestone/.claude-plugin/plugin.json` (0.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)