### PR TITLE
marketplace: bump lodestone to 0.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "piercelamb-plugins",
   "description": "Claude Code plugins by Pierce Lamb",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "owner": {
     "name": "Pierce Lamb",
     "url": "https://github.com/piercelamb"
@@ -72,7 +72,7 @@
     {
       "name": "lodestone",
       "description": "Local research corpus over arXiv papers, blog posts, and code repos with paper-grounded MCP search/read tools",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"


### PR DESCRIPTION
Sync lodestone entry to 0.1.2 per piercelamb/lodestone#75 (doctor `!`-injection rejection fix on `$HOME`). Catalog patch 1.1.1 → 1.1.2. Single-file two-line diff.