### PR TITLE
marketplace: bump lodestone 0.3.0 + deep-sota 0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,7 +56,7 @@
     {
       "name": "deep-sota",
       "description": "Paper- and repo-grounded research over the lodestone knowledge base",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "piercelamb-plugins",
   "description": "Claude Code plugins by Pierce Lamb",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "owner": {
     "name": "Pierce Lamb",
     "url": "https://github.com/piercelamb"
@@ -72,7 +72,7 @@
     {
       "name": "lodestone",
       "description": "Local research corpus over arXiv papers, blog posts, and code repos with paper-grounded MCP search/read tools",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"


### PR DESCRIPTION
Sync catalog to 1.1.4: lodestone 0.2.0 → 0.3.0 (piercelamb/lodestone#82), deep-sota 0.2.0 → 0.2.1 (piercelamb/deep-sota#19).