### PR TITLE
marketplace: bump lodestone to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "piercelamb-plugins",
   "description": "Claude Code plugins by Pierce Lamb",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "owner": {
     "name": "Pierce Lamb",
     "url": "https://github.com/piercelamb"
@@ -72,7 +72,7 @@
     {
       "name": "lodestone",
       "description": "Local research corpus over arXiv papers, blog posts, and code repos with paper-grounded MCP search/read tools",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "piercelamb",
         "url": "https://github.com/piercelamb"


### PR DESCRIPTION
Sync lodestone entry to 0.3.1 (catalog 1.1.4 → 1.1.5) per piercelamb/lodestone#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)