### PR TITLE
Fix section-writer SubagentStop hook on Windows (path, preamble, encoding)

### DIFF
--- a/agents/section-writer.md
+++ b/agents/section-writer.md
@@ -12,7 +12,10 @@ You are a section-writer agent for the deep-plan workflow. Your job is to genera
 1. Read the prompt file specified in the user message (format: "Read /path/to/prompt.md and execute...")
 2. Read all context files referenced in the prompt
 3. Generate the section content as specified
-4. Output ONLY the raw markdown content for the section
+4. Output ONLY the raw markdown content for the section. Start your response
+   DIRECTLY with the section's first Markdown heading (e.g. "# Section ..."). Do
+   NOT write any preamble, acknowledgement, or explanation before it (no "I have
+   all the context...", no "Here is the section..."), and write nothing after it.
 
 **Important:** A SubagentStop hook automatically extracts your output and writes it to the correct
 file location. You do NOT need to output JSON or specify the filename - just output the

--- a/scripts/hooks/write-section-on-stop.py
+++ b/scripts/hooks/write-section-on-stop.py
@@ -38,7 +38,7 @@ def debug_log(msg: str) -> None:
         return
     try:
         DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
-        with open(DEBUG_LOG, "a") as f:
+        with open(DEBUG_LOG, "a", encoding="utf-8") as f:
             f.write(f"{datetime.now().isoformat()} {msg}\n")
     except OSError:
         pass
@@ -93,6 +93,25 @@ def wait_for_stable_file(path: str, stability_ms: int = 200, timeout_s: float = 
         time.sleep(poll_ms / 1000)
 
     debug_log(f"Timeout waiting for stable file (last_size={last_size})")
+
+
+def strip_preamble(content: str) -> str:
+    """Entferne ein vom Modell evtl. vorangestelltes Vorwort vor der ersten
+    Markdown-Ueberschrift.
+
+    Section-Dateien beginnen per Konvention mit einer Ueberschrift ('# ...').
+    Manche Subagent-Laeufe stellen trotz Prompt einen Einleitungssatz voran
+    (z.B. "I have all the context I need ..."). Wir schneiden alles vor der
+    ersten Zeile weg, die (nach optionalem Whitespace) mit '#' beginnt.
+
+    - Beginnt der Inhalt bereits mit einer Ueberschrift -> unveraendert.
+    - Wird gar keine Ueberschrift gefunden -> unveraendert (kein Datenverlust).
+    """
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            return content if i == 0 else "\n".join(lines[i:])
+    return content
 
 
 def main() -> int:
@@ -157,6 +176,10 @@ def main() -> int:
         debug_log(f"Failed to get assistant content: {e}")
         return 0
 
+    # Ein evtl. vorangestelltes Modell-Vorwort vor der ersten Ueberschrift entfernen.
+    content = strip_preamble(content)
+    debug_log(f"Content length after strip_preamble: {len(content)} bytes")
+
     # 6. Write to destination
     sections_path = Path(sections_dir)
     if not sections_path.exists():
@@ -165,7 +188,9 @@ def main() -> int:
 
     output_path = sections_path / filename
     try:
-        output_path.write_text(content)
+        # encoding explizit: Windows-Default ist cp1252 und zerstoert Umlaute /
+        # Sonderzeichen (—, ae/oe/ue). Lesen nutzt ebenfalls utf-8 (transcript_parser).
+        output_path.write_text(content, encoding="utf-8")
         debug_log(f"Wrote {len(content)} bytes to {output_path}")
 
         # Verify write

--- a/scripts/lib/transcript_parser.py
+++ b/scripts/lib/transcript_parser.py
@@ -54,7 +54,7 @@ def read_transcript_entries(transcript_path: str) -> Iterator[dict]:
     if not path.exists():
         raise FileNotFoundError(f"Transcript not found: {transcript_path}")
 
-    for line_num, line in enumerate(path.read_text().strip().split('\n'), 1):
+    for line_num, line in enumerate(path.read_text(encoding='utf-8').strip().split('\n'), 1):
         line = line.strip()
         if not line:
             continue
@@ -170,8 +170,10 @@ def extract_prompt_file_path(user_message: str) -> str:
     Raises:
         ValueError: If pattern not found or file doesn't end in .md
     """
-    # Pattern: "Read /absolute/path/to/file.md and execute"
-    match = re.search(r'Read\s+(/[^\s]+\.md)\s+and execute', user_message)
+    # Pattern: "Read <absolute path>.md and execute" — der Pfad kann Unix (/...)
+    # ODER Windows (C:/...) sein. Darum KEIN fuehrendes '/' erzwingen, sonst
+    # findet der Hook auf Windows den Pfad nie und schreibt keine Section-Datei.
+    match = re.search(r'Read\s+([^\s]+\.md)\s+and execute', user_message)
     if match:
         return match.group(1)
     raise ValueError("Could not find prompt file path in user message")

--- a/tests/test_write_section_on_stop.py
+++ b/tests/test_write_section_on_stop.py
@@ -567,3 +567,86 @@ class TestWaitForStableFile:
         # Must contain the REAL section content, not the intermediate message
         assert "REAL section content" in content
         assert "different approach" not in content
+
+
+class TestStripPreamble:
+    """Tests for strip_preamble() — removes model preamble before first heading."""
+
+    def test_removes_preamble_before_heading(self):
+        content = "I have all the context I need.\n\n# Section 01\n\nBody text."
+        assert _mod.strip_preamble(content) == "# Section 01\n\nBody text."
+
+    def test_unchanged_when_starts_with_heading(self):
+        content = "# Section 01\n\nBody text."
+        assert _mod.strip_preamble(content) == content
+
+    def test_unchanged_when_no_heading(self):
+        content = "Just prose, no markdown heading at all."
+        assert _mod.strip_preamble(content) == content
+
+    def test_multiline_preamble_removed(self):
+        content = "Line one of preamble.\nLine two.\n\n## Sub heading\n\nBody."
+        assert _mod.strip_preamble(content) == "## Sub heading\n\nBody."
+
+
+class TestPreambleE2E:
+    """End-to-end: a transcript whose final assistant message has a preamble
+    must produce a section file WITHOUT the preamble."""
+
+    @pytest.fixture
+    def hook_script(self):
+        return Path(__file__).parent.parent / "scripts" / "hooks" / "write-section-on-stop.py"
+
+    def test_preamble_stripped_from_written_file(self, hook_script, tmp_path):
+        sections_dir = tmp_path / "sections"
+        sections_dir.mkdir()
+        prompts_dir = sections_dir / ".prompts"
+        prompts_dir.mkdir()
+        prompt_file = prompts_dir / "section-01-foo-prompt.md"
+        prompt_file.write_text("# Prompt")
+
+        transcript_path = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"message": {"role": "user", "content": f"Read {prompt_file} and execute"}}),
+            json.dumps({"message": {"role": "assistant",
+                                    "content": "I have all the context I need. I'll now write it.\n\n# Section 01: Foo\n\nReal body."}}),
+        ]
+        transcript_path.write_text("\n".join(lines))
+
+        result = subprocess.run(
+            ["uv", "run", str(hook_script)],
+            input=json.dumps({"agent_transcript_path": str(transcript_path)}),
+            capture_output=True, text=True, env=get_test_env(tmp_path),
+        )
+        assert result.returncode == 0
+        out = (sections_dir / "section-01-foo.md").read_text()
+        assert out.startswith("# Section 01: Foo")
+        assert "I have all the context" not in out
+
+    def test_utf8_content_written_correctly(self, hook_script, tmp_path):
+        """Umlaute / em-dash duerfen beim Schreiben nicht zerstoert werden
+        (Windows-Default-Encoding cp1252 wuerde sie kaputtmachen)."""
+        sections_dir = tmp_path / "sections"
+        sections_dir.mkdir()
+        prompts_dir = sections_dir / ".prompts"
+        prompts_dir.mkdir()
+        prompt_file = prompts_dir / "section-02-umlaut-prompt.md"
+        prompt_file.write_text("# Prompt")
+
+        body = "# Section 02 — Konfiguration\n\nÄnderung an Sprüchen: ö ä ü ß."
+        transcript_path = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"message": {"role": "user", "content": f"Read {prompt_file} and execute"}}),
+            json.dumps({"message": {"role": "assistant", "content": body}}),
+        ]
+        transcript_path.write_text("\n".join(lines), encoding="utf-8")
+
+        result = subprocess.run(
+            ["uv", "run", str(hook_script)],
+            input=json.dumps({"agent_transcript_path": str(transcript_path)}),
+            capture_output=True, text=True, env=get_test_env(tmp_path),
+        )
+        assert result.returncode == 0
+        out = (sections_dir / "section-02-umlaut.md").read_text(encoding="utf-8")
+        assert "—" in out and "Sprüchen" in out and "ß" in out
+        assert "�" not in out  # kein Ersatzzeichen


### PR DESCRIPTION
## Problem

On Windows, the `section-writer` `SubagentStop` hook (`scripts/hooks/write-section-on-stop.py`) never wrote any section files. Three issues:

1. **Prompt-path regex is Unix-only.** `extract_prompt_file_path` uses `r'Read\s+(/[^\s]+\.md)\s+and execute'`, which requires a leading `/`. Windows paths (`C:/.../section-01-...-prompt.md`) never match, so the hook raises `ValueError` and exits without writing — the user has to write every section file by hand.
2. **Model preamble leaks into the file.** The subagent sometimes prefixes a sentence ("I have all the context I need...") before the first heading; `find_last_assistant_text_message` returns it verbatim, so it lands in the section file.
3. **Encoding corrupts non-ASCII.** `output_path.write_text(content)` uses the platform default (cp1252 on Windows), turning em-dashes / umlauts into `�`. (Reads already use `encoding='utf-8'`.)

## Fix

- Drop the leading-`/` requirement in the regex so both Unix (`/...`) and Windows (`C:/...`) paths match.
- Add `strip_preamble()` — keep everything from the first Markdown heading. No-op if the content already starts with a heading; no-op (no data loss) if there is no heading at all.
- Write with `encoding='utf-8'` (and the debug log too).
- Strengthen the `section-writer` agent prompt to start directly with the heading and add no preamble.

## Tests

Added `TestStripPreamble`, a preamble E2E test, and a UTF-8 round-trip test. All 28 tests pass (`tests/test_write_section_on_stop.py` + `tests/test_hooks.py`).

Verified end-to-end on Windows against real subagent transcripts: all 5 section files now write automatically, with correct umlauts and no preamble.
